### PR TITLE
Allow plugins with zero reported channels to load (rnnoise.vst3)

### DIFF
--- a/Source/AudioEngine.cpp
+++ b/Source/AudioEngine.cpp
@@ -2263,13 +2263,10 @@ void AudioEngine::loadActivePlugins()
 
 		if (plugin.numInputChannels <= 0 || plugin.numOutputChannels <= 0)
 		{
-			const String errorMessage = "Plugin does not expose audio input and output channels";
-			const auto message = "Light Host Modern: failed to load plugin '" + plugin.name + "': " + errorMessage;
-			Logger::writeToLog(message);
-			lightHostLog(message);
-			pluginStateStore.setValue("failed", plugin, errorMessage);
-			markSettingsDirty();
-			continue;
+			// Mirrors addKnownPluginByIndex: zero-channel scan descriptions are not authoritative.
+			const auto warningMessage = "Light Host Modern: plugin reports no audio input/output channels; attempting load anyway '" + plugin.name + "'";
+			Logger::writeToLog(warningMessage);
+			lightHostLog(warningMessage);
 		}
 
 		const bool bypass = pluginStateStore.getValue("bypass", plugin).getIntValue() != 0;
@@ -2415,10 +2412,11 @@ bool AudioEngine::addKnownPluginByIndex(int sortedIndex)
 
 	if (plugin.numInputChannels <= 0 || plugin.numOutputChannels <= 0)
 	{
-		const auto rejectMessage = "Light Host Modern: rejected plugin without audio input/output before load '" + plugin.name + "'";
-		Logger::writeToLog(rejectMessage);
-		lightHostLog(rejectMessage);
-		return false;
+		// Zero-channel scan descriptions are not authoritative (e.g. RNNoise VST3);
+		// instantiation exposes real buses, so let the instance path be the gate.
+		const auto warningMessage = "Light Host Modern: plugin reports no audio input/output channels before load; attempting load anyway '" + plugin.name + "'";
+		Logger::writeToLog(warningMessage);
+		lightHostLog(warningMessage);
 	}
 
 	const auto activeTypes = activePluginList.getTypes();


### PR DESCRIPTION
#3: 

*Disclaimer: PR made with heavy assistance from DSV4 Flash on Pi harness*.

Given maintainer's stance on LLM assistance I believe the below context will help more than hinder:

Loading `rnnoise.vst3` from https://github.com/werman/noise-suppression-for-voice fails with:

> Plugin could not be loaded. It may not expose audio input and output channels.

The plugin works in the original Light Host. 

`AudioEngine::addKnownPluginByIndex` rejects the add when the scanned `PluginDescription` reports `numInputChannels <= 0 || numOutputChannels <= 0`. RNNoise's VST3 scan description reports 0 in / 0 out, but the instantiated plugin exposes real audio buses (1 in / 1 out) — description channel counts are not a reliable pre-load rejection signal.

## Change
One commit [a8c741e](https://github.com/heide-oficial/Light-Host-Modern/pull/4/commits/a8c741e1cdcf21f5511a92393e81c49c0d9151de): Allow zero-channel plugins to load (RNNoise VST3).

Relaxes the pre-load rejection of plugins whose scan description reports zero audio channels — the hard rejection becomes a logged warning and the instance-creation path decides. Applied at both entry points in Source/AudioEngine.cpp:

 - addKnownPluginByIndex — manual add (UI / IPC)
 - loadActivePlugins — startup auto-restore of the active plugin chain

RNNoise VST3 reports zero channels in its scan description but exposes real audio buses once instantiated, so it was rejected before ever being loaded.

 Why it's safe:
 - PluginSlot clamps channel counts to jmax(1, ...) from the instance's actual getTotalNumInputChannels() / getTotalNumOutputChannels(), so real buses are wired correctly
 - Broken plugins still fail at createPluginInstance (null instance / exception) → marked failed, logged, add rolled back
 - Original Light Host applies no such pre-load check on the add path

Verified over the named-pipe IPC: add-known-plugin:61 → {"status":"ok","addedActive":1}; host log confirms instance created, PluginSlot added, plugin loaded successfully.

*Genuinely busless VSTs have not been E2E tested, and neither stereo audio.*

## Verification

Manual E2E after building winUI, my old VST stack from Light Host (RNNoise, khs gate, khs compressor, Pro-Q 3, T De-Esser 2) now also works as expected on LHM:

<img width="1920" height="1017" alt="screenshot of plugins page with mentioned plugins loaded" src="https://github.com/user-attachments/assets/afce577a-9bc4-4eb3-a061-0b28fb478531" />

DSV4 on Pi running on Windows 11 23H2 has verified using host layer via named-pipe IPC:

1. Launch host with `--debug`
2. `add-known-plugin:61` (RNNoise VST3)

Result: `{"status":"ok","addedActive":1}` — previously rejected with
`rejected plugin without audio input/output before load`. Host log confirms
instance created, `PluginSlot` added, `plugin loaded successfully`.

